### PR TITLE
Updated copyright to 2022 and owned by STFC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 stur86
+Copyright (c) 2022 Science and Technology Facilities Council
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I've updated the licence file for this year and changed the licence-holder to be STFC in preparation for the CCP-NC fork to become the de-facto official one. Thanks @stur86 ! 